### PR TITLE
Fix horrifying omission (missing property on the ICentralServerService interface)

### DIFF
--- a/Ssmp/CentralServerService.cs
+++ b/Ssmp/CentralServerService.cs
@@ -10,6 +10,8 @@ namespace Ssmp
 {
     public interface ICentralServerService
     {
+        ImmutableList<ConnectedClient> ConnectedClients { get; }
+
         Task SpinOnce();
     }
     


### PR DESCRIPTION
Fix missing property on the `ICentralServerService` interface.